### PR TITLE
Add shebang lines

### DIFF
--- a/plugin/vmux_send_cmd
+++ b/plugin/vmux_send_cmd
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # make sure the shell and vim working directory are aligned
 vmux_send :cd $PWD
 vmux_send :$(basename $0) "$@"

--- a/plugin/vmux_send_winc_l
+++ b/plugin/vmux_send_winc_l
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 caller=$(basename $0)
 # make sure the shell and vim working directory are aligned
 vmux_send :cd $PWD

--- a/plugin/vmux_send_winc_t
+++ b/plugin/vmux_send_winc_t
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 caller=$(basename $0)
 # make sure the shell and vim working directory are aligned
 vmux_send :cd $PWD


### PR DESCRIPTION
This fixes the string substitutions on systems where the default shell
is not bash